### PR TITLE
Add BannerTitle TimelineItemAttribute in order to support new Notification Design

### DIFF
--- a/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/blobdb/Timeline.kt
+++ b/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/blobdb/Timeline.kt
@@ -263,6 +263,7 @@ enum class TimelineAttribute(val id: UByte, val maxLength: Int = -1) {
     DisplayTime(0x26u),
     SubtitleTemplateString(0x2Fu, 150),
     Icon(0x30u),
+    BannerTitle(0x31u, 64),
 }
 
 fun timelinePacketsRegister() {

--- a/src/commonMain/kotlin/io/rebble/libpebblecommon/util/TimelineAttributeFactory.kt
+++ b/src/commonMain/kotlin/io/rebble/libpebblecommon/util/TimelineAttributeFactory.kt
@@ -34,6 +34,10 @@ object TimelineAttributeFactory {
         return createAttribute(type.id, content)
     }
 
+    fun bannerTitle(text: String): TimelineItem.Attribute {
+        return createTextAttribute(TimelineAttribute.BannerTitle, text);
+    }
+
     fun title(text: String): TimelineItem.Attribute {
         return createTextAttribute(TimelineAttribute.Title, text)
     }


### PR DESCRIPTION
The new notification design (https://github.com/pebble-dev/pebble-firmware/pull/52) adds a "BannerTitle" attribute that can be set