### PR TITLE
Add .kotlin build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea
 /.gradle
 **.DS_Store
+/.kotlin


### PR DESCRIPTION
Kotlin 2 added this new build directory and it should be ignored


<img width="817" alt="Screenshot 2025-03-02 at 10 06 04 AM" src="https://github.com/user-attachments/assets/8b022048-4bdc-49af-a1d0-93873ec91e96" />
